### PR TITLE
Add footer to library file

### DIFF
--- a/kipart/kipart.py
+++ b/kipart/kipart.py
@@ -221,6 +221,7 @@ PIN_STYLES = {scrubber.sub("", k).lower(): v for k, v in list(PIN_STYLES.items()
 
 # Format strings for various items in a KiCad part library.
 LIB_HEADER = "EESchema-LIBRARY Version 2.3\n"
+LIB_FOOTER = "#End Library\n"
 START_DEF = "DEF {name} {ref} 0 {pin_name_offset} {show_pin_number} {show_pin_name} {num_units} L N\n"
 END_DEF = "ENDDEF\n"
 REF_FIELD = 'F0 "{ref_prefix}" {x} {y} {font_size} H V {text_justification} CNN\n'
@@ -869,10 +870,12 @@ def read_lib_file(lib_file):
 def write_lib_file(parts_lib, lib_file):
     print("Writing", lib_file, len(parts_lib))
     LIB_HEADER = "EESchema-LIBRARY Version 2.3\n"
+    LIB_FOOTER = "#End Library\n"
     with open(lib_file, "w") as lib_fp:
         lib_fp.write(LIB_HEADER)
         for part_def in parts_lib.values():
             lib_fp.write(part_def)
+        lib_fp.write(LIB_FOOTER)
 
 
 def call_kipart(args, part_reader, part_data_file, file_name, file_type, parts_lib):


### PR DESCRIPTION
KiBot (https://github.com/INTI-CMNB/KiBot) expects a footer in symbol
library file. In file v5_sch.py LibLineReader searches for
'#End Library' or '# End Library'.

Also, in one KiCad 5 tutorial there is a footer '#End Library'.
(https://docs.kicad.org/5.0/en/getting_started_in_kicad/getting_started_in_kicad.html)

I am not sure if this footer serves any function in KiCad, but by adding
it I get rid of one problem in KiBot.