### PR TITLE
Remove redundant old_div

### DIFF
--- a/kipart/kipart.py
+++ b/kipart/kipart.py
@@ -38,7 +38,6 @@ from copy import copy
 from pprint import pprint
 
 from affine import Affine
-from past.utils import old_div
 
 from .common import *
 from .pckg_info import __version__
@@ -298,7 +297,7 @@ def pins_bbox(unit_pins):
     width += PIN_LENGTH + 2 * PIN_NAME_OFFSET
 
     # Make bounding box an integer number of pin spaces so pin connections are always on the grid.
-    width = math.ceil(old_div(float(width), PIN_SPACING)) * PIN_SPACING
+    width = math.ceil(float(width) / PIN_SPACING) * PIN_SPACING
 
     # Compute the height of the column of pins.
     height = count_pin_slots(unit_pins) * PIN_SPACING


### PR DESCRIPTION
Probably as part of 2to3, a usage of old_div was added to one of the width calculations in kipart.  Since there's explicit float casting involved already, calling old_div is redundant (since all it does is *avoid* a type change to float when two integers are divided).

Remove it, to remove a false dependency on `past`.