### PR TITLE
Multiple asterisk prefixes denote multiple spaces

### DIFF
--- a/kipart/kipart.py
+++ b/kipart/kipart.py
@@ -257,8 +257,8 @@ def get_pin_num_and_spacer(pin):
     pin_num = str(pin.num)
     pin_spacer = 0
     # spacer pins have pin numbers starting with a special prefix char.
-    if pin_num.startswith(PIN_SPACER_PREFIX):
-        pin_spacer = 1
+    while pin_num.startswith(PIN_SPACER_PREFIX):
+        pin_spacer += 1
         pin_num = pin_num[1:]  # Remove the spacer prefix.
     return pin_num, pin_spacer
 
@@ -424,11 +424,7 @@ def draw_pins(unit_num, unit_pins, bbox, transform, side, push, fuzzy_match):
         num_size = PIN_NUM_SIZE if len(pins) == 1 else 0
         for index, pin in enumerate(pins):
 
-            pin_num = str(pin.num)
-
-            # Remove any spacer prefix on the pin numbers.
-            if pin_num.startswith(PIN_SPACER_PREFIX):
-                pin_num = pin_num[1:]
+            pin_num, _ = get_pin_num_and_spacer(pin)
 
             # Create a pin using the pin data.
             pin_defn += PIN.format(


### PR DESCRIPTION
This allows shorthand for adding multiple spaces:

```
pin1
***
pin2
**pin3
```

expands into

```
pin1
_
_
_
pin2
_
_
pin3
```