### PR TITLE
Made dependency on future python 2 only

### DIFF
--- a/kipart/kilib2csv.py
+++ b/kipart/kilib2csv.py
@@ -34,7 +34,6 @@ import re
 import sys
 from builtins import open
 
-from future import standard_library
 from pyparsing import *
 import sexpdata as sx
 
@@ -42,7 +41,9 @@ from .common import issue
 from .pckg_info import __version__
 from .py_2_3 import *
 
-standard_library.install_aliases()
+if sys.version_info[0] < 3:
+    from future import standard_library
+    standard_library.install_aliases()
 
 
 def _parse_lib_V5(lib_filename):

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("HISTORY.rst") as history_file:
 
 requirements = [
     "affine >= 1.2.0",
-    "future",
+    "future; python_version<'3'",
     # "future >= 0.15.0",
     "pyparsing",
     "openpyxl",

--- a/tests/random_csv.py
+++ b/tests/random_csv.py
@@ -34,9 +34,9 @@ import sys
 from builtins import open
 from random import choice, randint
 
-from future import standard_library
-
-standard_library.install_aliases()
+if sys.version_info[0] < 3:
+    from future import standard_library
+    standard_library.install_aliases()
 
 
 THIS_MODULE = locals()


### PR DESCRIPTION
KiPart has a dependency on the "future" module.  Going through the code I found that the only use of this module is two instances of calling `future.standard_library.install_aliases()`.  This function is defined as doing nothing at all on python 3.  Thus, the call is only needed on python 2 and it's simple to make it so that it is only called on python 2, making the dependency not needed on python 3.

Why is this important?  Well, with python 2 having become EOL, distributions are starting to remove python 2, and also the future module (see e.g. https://bugs.gentoo.org/888271).  Thus, requiring the module in order to install for python 3 makes packaging difficult (or at least awkward).

Note that uses of `__future__` (with the underscores) are not affected by this at all, since that is a builtin "module" and guaranteed to be available in every Python installation.